### PR TITLE
Feat: Add GetStreamsAPI Interface

### DIFF
--- a/example/demo_livesaas/demo_livesaas_test.go
+++ b/example/demo_livesaas/demo_livesaas_test.go
@@ -213,3 +213,25 @@ func TestLIVESAAS_ListActivityFeedInfosAPI(t *testing.T) {
 	// Print the response data
 	t.Logf("statusCode = %+v  msgInfo = %+v \n", statusCode, string(res))
 }
+
+func TestLIVESAAS_GetStreamsAPI(t *testing.T) {
+	livesaas.DefaultInstance.Client.SetAccessKey(testAk)
+	livesaas.DefaultInstance.Client.SetSecretKey(testSk)
+	livesaas.DefaultInstance.Client.SetTimeout(time.Second * 10)
+
+	// Print the request parameters
+	query := url.Values{}
+	query.Set("ActivityId", activity_id)
+
+	// Call the API operation to create a live-streaming activity with the serialized request parameters
+	resp, statusCode, err := livesaas.DefaultInstance.GetStreamsAPI(query)
+
+	// If an error occurs while calling the API operation, print the error
+	if err != nil {
+		t.Logf("error occur %v", err)
+	}
+	// Serialize the response data
+	res, _ := json.Marshal(resp)
+	// Print the response data
+	t.Logf("statusCode = %+v  msgInfo = %+v \n", statusCode, string(res))
+}

--- a/service/livesaas/config.go
+++ b/service/livesaas/config.go
@@ -89,6 +89,14 @@ var (
 				"Version": []string{ServiceVersion20230801},
 			},
 		},
+		"GetStreamsAPI": {
+			Method: http.MethodGet,
+			Path:   "/",
+			Query: url.Values{
+				"Action":  []string{"GetStreamsAPI"},
+				"Version": []string{ServiceVersion20200601},
+			},
+		},
 	}
 )
 

--- a/service/livesaas/model.go
+++ b/service/livesaas/model.go
@@ -586,3 +586,38 @@ type ActivityFeedInfo struct {
 	CreateTime            int64        `thrift:"CreateTime,10" frugal:"10,default,i64" json:"CreateTime"`
 	SiteTags              []*ActTagAPI `thrift:"SiteTags,11" frugal:"11,default,list<ActTagAPI>" json:"SiteTags"`
 }
+
+type StreamLineDetail struct {
+	LineID       int    `thrift:"LineID,1" frugal:"1,default,string" json:"LineID"`
+	LineName     string `thrift:"LineName,2" frugal:"2,default,string" json:"LineName"`
+	MainPushInfo struct {
+		PushPath      string `thrift:"PushPath,1" frugal:"1,default,string" json:"PushPath"`
+		StreamingCode string `thrift:"StreamingCode,2" frugal:"2,default,string" json:"StreamingCode"`
+		PushURL       string `thrift:"PushUrl,3" frugal:"3,default,string" json:"PushUrl"`
+	} `thrift:"MainPushInfo,3" frugal:"3,default,MainPushInfo" json:"MainPushInfo"`
+	BackPushInfo struct {
+		PushPath      string `thrift:"PushPath,1" frugal:"1,default,string" json:"PushPath"`
+		StreamingCode string `thrift:"StreamingCode,2" frugal:"2,default,string" json:"StreamingCode"`
+		PushURL       string `thrift:"PushUrl,3" frugal:"3,default,string" json:"PushUrl"`
+	} `thrift:"BackPushInfo,4" frugal:"4,default,BackPushInfo" json:"BackPushInfo"`
+	ForwardInfo struct {
+		PullStreamURL         string `thrift:"PullStreamUrl,1" frugal:"1,default,string" json:"PullStreamUrl"`
+		PullStreamStatus      int    `thrift:"PullStreamStatus,2" frugal:"2,default,i32" json:"PullStreamStatus"`
+		PullStreamCheckStatus int    `thrift:"PullStreamCheckStatus,3" frugal:"3,default,i32" json:"PullStreamCheckStatus"`
+	} `thrift:"ForwardInfo,5" frugal:"5,default,ForwardInfo" json:"ForwardInfo"`
+	BackupForwardInfo struct {
+		PullStreamURL         string `thrift:"PullStreamUrl,1" frugal:"1,default,string" json:"PullStreamUrl"`
+		PullStreamStatus      int    `thrift:"PullStreamStatus,2" frugal:"2,default,i32" json:"PullStreamStatus"`
+		PullStreamCheckStatus int    `thrift:"PullStreamCheckStatus,3" frugal:"3,default,i32" json:"PullStreamCheckStatus"`
+	} `thrift:"BackupForwardInfo,6" frugal:"6,default,BackupForwardInfo" json:"BackupForwardInfo"`
+	ExpireTime int `thrift:"ExpireTime,7" frugal:"7,default,i32" json:"ExpireTime"`
+}
+
+type GetStreamsResponseBody struct {
+	LineDetails []StreamLineDetail `thrift:"LineDetails,2" frugal:"2,default,string" json:"LineDetails"`
+}
+
+type GetStreamsResponse struct {
+	ResponseMetadata base.ResponseMetadata
+	Result           *GetStreamsResponseBody `json:"Result,omitempty"`
+}

--- a/service/livesaas/wrapper.go
+++ b/service/livesaas/wrapper.go
@@ -99,3 +99,12 @@ func (p *LIVESAAS) ListActivityFeedInfosAPI(query url.Values) (*ListActivityFeed
 	}
 	return resp, statesCode, nil
 }
+
+func (p *LIVESAAS) GetStreamsAPI(query url.Values) (*GetStreamsResponse, int, error) {
+	resp := new(GetStreamsResponse)
+	statesCode, err := p.commonHandler("GetStreamsAPI", query, resp)
+	if err != nil {
+		return nil, statesCode, err
+	}
+	return resp, statesCode, nil
+}


### PR DESCRIPTION
**Summary**

This PR enhances the Byteplus Live Go SDK by implementing the [GetStreamsAPI](https://docs.byteplus.com/en/docs/byteplus-livesaas/docs-getstreamsapi). This addition enables programmatic retrieval of the push URL while leveraging the SDK's on-the-fly authentication mechanism.

Please let me know if anything needs to be updated to align with best practices or meet your requirements. 

cc: @peikai-wang @liuweiwei-xyz @guozhifeng-felton @cbsfly @KArtorias